### PR TITLE
Develop

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -128,6 +128,18 @@ paths:
                 items:
                   type: string
       security: [] # Remove the API_TOKEN requirement for this endpoint
+  /try:
+    get:
+      summary: Get a trial API-key
+      operationId: /try
+      responses:
+        "200":
+          description: Returns a 15-minute temporary API-key
+          content:
+            application/json:
+              schema:
+                type: string
+      security: [] # Remove the API_TOKEN requirement for this endpoint
 
 security:
   - API_TOKEN: []


### PR DESCRIPTION
* Added edge case and error message saying "Missing or invalid API key" if someone tries using the execute btn without specifying api-key
*Added /try swagger ui where users can generate a trial API key
