### PR TITLE
change order of endpoints + remove error responses

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -35,6 +35,18 @@ servers:
   - url: https://api.everyname.xyz/
 
 paths:
+  /try:
+    get:
+      summary: Get a trial API-key
+      operationId: /try
+      responses:
+        "200":
+          description: Returns a 15-minute temporary API-key
+          content:
+            application/json:
+              schema:
+                type: string
+      security: [] # Remove the API_TOKEN requirement for this endpoint
   /forward:
     get:
       summary: Forward Resolution
@@ -101,16 +113,6 @@ paths:
                     type: string
                   name:
                     type: string
-        "401":
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    example: Require api-key to execute...
       security:
         - API_TOKEN: []
       x-security-headers:
@@ -129,19 +131,6 @@ paths:
                 items:
                   type: string
       security: [] # Remove the API_TOKEN requirement for this endpoint
-  /try:
-    get:
-      summary: Get a trial API-key
-      operationId: /try
-      responses:
-        "200":
-          description: Returns a 15-minute temporary API-key
-          content:
-            application/json:
-              schema:
-                type: string
-      security: [] # Remove the API_TOKEN requirement for this endpoint
-
 security:
   - API_TOKEN: []
 components:


### PR DESCRIPTION
Reordered the paths so that 'trial api key' comes first, also removed the error response in one of the endpoints which was not necessary to show.